### PR TITLE
Add support for xbox/windows store games

### DIFF
--- a/steamsync-library/setup.py
+++ b/steamsync-library/setup.py
@@ -12,18 +12,15 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/jaydenmilne/steamsync",
-    packages=setuptools.find_packages('src'),
-    package_dir={'': 'src'},
+    packages=setuptools.find_packages("src"),
+    package_dir={"": "src"},
     classifiers=[
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
         "Topic :: Games/Entertainment",
-
     ],
-    install_requires=[
-        'vdf>=3,<4'
-    ],
+    install_requires=["vdf>=3,<4"],
     scripts=["src/steamsync.py"],
-    python_requires='>=3.6',
+    python_requires=">=3.6",
 )

--- a/steamsync-library/src/defs.py
+++ b/steamsync-library/src/defs.py
@@ -2,9 +2,11 @@
 
 TAG_EPIC = "epicstore"
 TAG_ITCH = "itchio"
+TAG_XBOX = "xbox"
 TAGS = [
     TAG_EPIC,
     TAG_ITCH,
+    TAG_XBOX,
 ]
 
 
@@ -25,6 +27,7 @@ class GameDefinition:
     ):
         self.app_name = app_name
         self.executable_path = executable_path
+        self.icon = executable_path
         self.display_name = display_name
         self.install_folder = install_folder
         self.launch_arguments = launch_arguments

--- a/steamsync-library/src/defs.py
+++ b/steamsync-library/src/defs.py
@@ -38,3 +38,7 @@ class GameDefinition:
         else:
             self.uri = None
         self.storetag = storetag
+
+    def __lt__(self, other):
+        # Sort by display_name
+        return self.display_name < other.display_name

--- a/steamsync-library/src/itch.py
+++ b/steamsync-library/src/itch.py
@@ -139,6 +139,7 @@ def itch_collect_games(path_to_library):
             )
 
     print(f"Collected {len(games)} games from the itch library")
+    games.sort()
     return games
 
 

--- a/steamsync-library/src/itch.py
+++ b/steamsync-library/src/itch.py
@@ -83,7 +83,7 @@ def itch_collect_games(path_to_library):
 
     itch_collect_games(str) -> list(defs.GameDefinition)
     """
-    print(f"Scanning itch library folder ({path_to_library})...")
+    print(f"\nScanning itch library folder ({path_to_library})...")
     root = Path(path_to_library)
     games = []
     for receipt in root.glob("*/.itch/receipt.json.gz"):

--- a/steamsync-library/src/list_xbox_games.ps1
+++ b/steamsync-library/src/list_xbox_games.ps1
@@ -28,7 +28,7 @@ foreach ($app in $targets)
                 PrettyName = $name
                 Icon = $icon
                 InstallLocation = $app.InstallLocation
-                #~ Aumid = $app.PackageFamilyName + "!" + $id
+                Aumid = $app.PackageFamilyName + "!" + $id
             };
         }
     }

--- a/steamsync-library/src/list_xbox_games.ps1
+++ b/steamsync-library/src/list_xbox_games.ps1
@@ -1,0 +1,40 @@
+# LICENSE: AGPLv3. See LICENSE at root of repo
+
+$targets = get-AppxPackage
+$targets = $targets.where{ -not $_.IsFramework }
+
+$apps = @()
+foreach ($app in $targets)
+{
+    try
+    {
+        $app_manifest = Get-AppxPackageManifest $app;
+        $id = $app_manifest.package.applications.application.id;
+        # Older games (like Prey) are App.
+        if ($id -eq 'Game' -or $id -eq 'App')
+        {
+            $name = $app_manifest.Package.Properties.DisplayName;
+            if ($name -like '*DisplayName*' -or $name -like '*ms-resource*')
+            {
+                # Invalid name is probably not a game.
+                continue;
+            }
+
+            # Small icon looks better in steam. The Square150x150Logo is better for a desktop shortcut.
+            $icon = $app.InstallLocation + "\" + $app_manifest.Package.Applications.Application.VisualElements.Square44x44Logo;
+            $apps += [pscustomobject]@{
+                Kind = $id
+                Appid = $app.Name
+                PrettyName = $name
+                Icon = $icon
+                InstallLocation = $app.InstallLocation
+                #~ Aumid = $app.PackageFamilyName + "!" + $id
+            };
+        }
+    }
+    catch
+    {
+    }
+}
+
+$apps | ConvertTo-Json -depth 100;

--- a/steamsync-library/src/list_xbox_games.ps1
+++ b/steamsync-library/src/list_xbox_games.ps1
@@ -9,28 +9,27 @@ foreach ($app in $targets)
     try
     {
         $app_manifest = Get-AppxPackageManifest $app;
+        # Lots of games use $id = Game. Older games (like Prey) are App. Some
+        # games use nonsense (Supraland, GenesisNoir). So we can't exclude
+        # based on id, but we can include if it's 'Game'.
         $id = $app_manifest.package.applications.application.id;
-        # Older games (like Prey) are App.
-        if ($id -eq 'Game' -or $id -eq 'App')
+        $name = $app_manifest.Package.Properties.DisplayName;
+        if ($name -like '*DisplayName*' -or $name -like '*ms-resource*')
         {
-            $name = $app_manifest.Package.Properties.DisplayName;
-            if ($name -like '*DisplayName*' -or $name -like '*ms-resource*')
-            {
-                # Invalid name is probably not a game.
-                continue;
-            }
-
-            # Small icon looks better in steam. The Square150x150Logo is better for a desktop shortcut.
-            $icon = $app.InstallLocation + "\" + $app_manifest.Package.Applications.Application.VisualElements.Square44x44Logo;
-            $apps += [pscustomobject]@{
-                Kind = $id
-                Appid = $app.Name
-                PrettyName = $name
-                Icon = $icon
-                InstallLocation = $app.InstallLocation
-                Aumid = $app.PackageFamilyName + "!" + $id
-            };
+            # Invalid name is probably not a game.
+            continue;
         }
+
+        # Small icon looks better in steam. The Square150x150Logo is better for a desktop shortcut.
+        $icon = $app.InstallLocation + "\" + $app_manifest.Package.Applications.Application.VisualElements.Square44x44Logo;
+        $apps += [pscustomobject]@{
+            Kind = $id
+            Appid = $app.Name
+            PrettyName = $name
+            Icon = $icon
+            InstallLocation = $app.InstallLocation
+            Aumid = $app.PackageFamilyName + "!" + $id
+        };
     }
     catch
     {

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -100,7 +100,7 @@ def egs_collect_games(egs_manifest_path):
     """
     Returns an array of GameDefinitions of all the installed EGS games
     """
-    print(f"Scanning EGS manifest store ({egs_manifest_path})...")
+    print(f"\nScanning EGS manifest store ({egs_manifest_path})...")
     # loop over every .item fiile
     pathlist = Path(egs_manifest_path).glob("*.item")
     games = list()
@@ -447,6 +447,7 @@ def main():
         games += itch_collect_games(args.itch_library)
     if defs.TAG_XBOX in args.source:
         games += xbox_collect_games()
+    print()
     print_games(games)
 
     if not args.all:

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -190,9 +190,9 @@ def print_games(games):
     """
     games = list of GameDefinition
     """
-    row_fmt = "{: >3} | {: <25} | {: <10} | {: <32} | {: <25}"
+    row_fmt = "{: >3} | {: <25} | {: <10} | {: <45} | {: <25}"
     print(row_fmt.format("Num", "Game Name", "Source", "App ID", "Install Path"))
-    print("=" * ((25 + 3) * 2 + 10 + 50 + 6))
+    print("=" * (3 + 25 + 10 + 45 + 25))
     for i, game in enumerate(games, start=1):
         print(
             row_fmt.format(

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -10,6 +10,7 @@ import math
 import vdf
 
 from itch import itch_collect_games
+from xbox import xbox_collect_games
 import defs
 
 
@@ -25,7 +26,7 @@ class SteamAccount:
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
-        description="Utility to import games from the Epic Games Store and itch.io to your Steam library",
+        description="Utility to import games from the Epic Games Store, Microsoft Store (Xbox for Windows), and itch.io to your Steam library",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
@@ -33,7 +34,7 @@ def parse_arguments():
         "--source",
         action="append",
         choices=defs.TAGS,
-        help="Storefronts with games to add to Steam. If unspecified, uses all sources.",
+        help="Storefronts with games to add to Steam. If unspecified, uses all sources. Use argument multiple times to select multiple sources (--source itchio --source xbox).",
         required=False,
     )
 
@@ -315,7 +316,7 @@ def to_shortcut(game, use_uri):
         "appname": game.display_name,
         "Exe": shortcut,
         "StartDir": game.install_folder,
-        "icon": game.executable_path,
+        "icon": game.icon,
         "ShortcutPath": "",
         "LaunchOptions": game.launch_arguments,
         "IsHidden": 0,
@@ -444,6 +445,8 @@ def main():
         games += egs_collect_games(args.egs_manifests)
     if defs.TAG_ITCH in args.source:
         games += itch_collect_games(args.itch_library)
+    if defs.TAG_XBOX in args.source:
+        games += xbox_collect_games()
     print_games(games)
 
     if not args.all:

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -183,6 +183,7 @@ def egs_collect_games(egs_manifest_path):
             )
 
     print(f"Collected {len(games)} games from the EGS manifest store")
+    games.sort()
     return games
 
 

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -191,7 +191,7 @@ def print_games(games):
     games = list of GameDefinition
     """
     row_fmt = "{: >3} | {: <25} | {: <10} | {: <45} | {: <25}"
-    print(row_fmt.format("Num", "Game Name", "Source", "App ID", "Install Path"))
+    print(row_fmt.format("Num", "Game Name", "Source", "App ID", "Executable"))
     print("=" * (3 + 25 + 10 + 45 + 25))
     for i, game in enumerate(games, start=1):
         print(
@@ -200,7 +200,7 @@ def print_games(games):
                 game.display_name[:25],
                 game.storetag,
                 game.app_name,
-                game.executable_path,
+                f"{game.executable_path} {game.launch_arguments}",
             )
         )
 

--- a/steamsync-library/src/util.py
+++ b/steamsync-library/src/util.py
@@ -3,6 +3,7 @@
 
 import os
 
+
 def is_executable_game(game_path):
     """Is the input path a real file that we have access to?
 
@@ -12,4 +13,3 @@ def is_executable_game(game_path):
         return game_path.is_file() and os.access(game_path, os.R_OK)
     except OSError:
         return False
-

--- a/steamsync-library/src/xbox.py
+++ b/steamsync-library/src/xbox.py
@@ -1,0 +1,105 @@
+#! /usr/bin/env python3
+
+# LICENSE: AGPLv3. See LICENSE at root of repo
+
+from pathlib import Path
+from xml.dom import minidom
+import json
+import subprocess
+
+import defs
+
+
+def _get_exe_from_config(path_to_config):
+    """Get the exe file name (not full path) to launch from the config.
+
+    _get_exe_from_config(Path) -> str
+    """
+    with path_to_config.open("r", encoding="utf-8") as f:
+        doc = minidom.parse(f)
+    exes = doc.getElementsByTagName("Executable")
+    for exe in exes:
+        return exe.getAttribute("Name")
+
+
+def xbox_collect_games():
+    """Collect a list of "Xbox" games from Microsoft Game Store.
+
+    xbox_collect_games() -> List[GameDefinition]
+    """
+    games = []
+
+    print("Scanning Xbox library...")
+    # Run string instead of scriptfile to circumvent powershell ExecutionPolicy
+    # ("cannot be loaded because running scripts is disabled on this system").
+    script = Path(__file__).resolve().parent / "list_xbox_games.ps1"
+    with script.open("r", encoding="utf-8") as f:
+        script_code = "".join(f.readlines())
+    output = subprocess.check_output(
+        ["powershell.exe", str(script_code)], universal_newlines=True
+    )
+    applist = json.loads(output)
+
+    for app in applist:
+        game_name = app["PrettyName"]
+        install = Path(app["InstallLocation"])
+        config = install / "MicrosoftGame.config"
+        # Hopefully filtering by MicrosoftGame excludes non-games. Older games
+        # like Prey 2017 are Kind='App' instead of 'Game'.
+        if not config.is_file():
+            if app["Kind"] == "Game":
+                print(
+                    f"Warning: Failed to find MicrosoftGame.config file for game '{game_name}'. Expected: {config}"
+                )
+            continue
+
+        exe_name = _get_exe_from_config(config)
+        if not exe_name:
+            continue
+
+        exe = install / exe_name
+        if not exe.is_file():
+            print(
+                f"Warning: Failed to find exe for game '{game_name}'. Expected: {exe}"
+            )
+            continue
+
+        game_def = defs.GameDefinition(
+            str(exe),
+            game_name,
+            app["Appid"],
+            str(exe.parent),
+            "",
+            defs.TAG_XBOX,
+        )
+        icon = Path(app["Icon"])
+        if not icon.is_file():
+            # Spiritfarer actually had Square44x44Logo.targetsize-48.png
+            ext = icon.suffix
+            icon = icon.with_suffix(".targetsize-48" + ext)
+        if not icon.is_file():
+            icon = exe
+        game_def.icon = str(icon)
+        games.append(game_def)
+
+    print(f"Collected {len(games)} games from the Xbox library")
+    return games
+
+
+def _test():
+    import pprint
+
+    pprint.pprint(
+        [
+            (
+                g.display_name,
+                g.executable_path,
+                g.app_name,
+            )
+            for g in xbox_collect_games()
+        ]
+    )
+
+
+if __name__ == "__main__":
+    _test()

--- a/steamsync-library/src/xbox.py
+++ b/steamsync-library/src/xbox.py
@@ -89,7 +89,8 @@ def xbox_collect_games():
         game_name = app["PrettyName"]
         install = Path(app["InstallLocation"])
         # Can't filter on Kind='Game' because older games like Prey 2017 are
-        # Kind='App'. Most games have a MicrosoftGame.config.
+        # Kind='App' and some put their name there! Most games have a
+        # MicrosoftGame.config.
         config = install / "MicrosoftGame.config"
         if config.is_file():
             exe_name, game_name = _get_details_from_config(config)

--- a/steamsync-library/src/xbox.py
+++ b/steamsync-library/src/xbox.py
@@ -10,16 +10,20 @@ import subprocess
 import defs
 
 
-def _get_exe_from_config(path_to_config):
+def _get_details_from_config(path_to_config):
     """Get the exe file name (not full path) to launch from the config.
 
-    _get_exe_from_config(Path) -> str
+    _get_details_from_config(Path) -> str,str
     """
     with path_to_config.open("r", encoding="utf-8") as f:
         doc = minidom.parse(f)
+    # "Tetris® Effect: Connected" instead of "Tetrisr Effect: Connected" from list_xbox_games.
+    display_name = doc.getElementsByTagName("ShellVisuals")[0].getAttribute(
+        "DefaultDisplayName"
+    )
     exes = doc.getElementsByTagName("Executable")
     for exe in exes:
-        return exe.getAttribute("Name")
+        return exe.getAttribute("Name"), display_name
 
 
 def xbox_collect_games():
@@ -46,7 +50,9 @@ def xbox_collect_games():
         config = install / "MicrosoftGame.config"
         # Hopefully filtering by MicrosoftGame excludes non-games. Older games
         # like Prey 2017 are Kind='App' instead of 'Game'.
-        if not config.is_file():
+        if config.is_file():
+            exe_name, game_name = _get_details_from_config(config)
+        else:
             if app["Kind"] == "Game":
                 print(
                     f"Warning: Failed to find MicrosoftGame.config file for game '{game_name}'. Expected: {config}"

--- a/steamsync-library/src/xbox.py
+++ b/steamsync-library/src/xbox.py
@@ -29,7 +29,7 @@ def xbox_collect_games():
     """
     games = []
 
-    print("Scanning Xbox library...")
+    print("\nScanning Xbox library...")
     # Run string instead of scriptfile to circumvent powershell ExecutionPolicy
     # ("cannot be loaded because running scripts is disabled on this system").
     script = Path(__file__).resolve().parent / "list_xbox_games.ps1"

--- a/steamsync-library/src/xbox.py
+++ b/steamsync-library/src/xbox.py
@@ -154,6 +154,7 @@ def xbox_collect_games():
         games.append(game_def)
 
     print(f"Collected {len(games)} games from the Xbox library")
+    games.sort()
     return games
 
 


### PR DESCRIPTION
This builds on top of changes from #8, so that commit is included here.

Uses a method similar to BrianLima/UWPHook to discover app packages. See
https://github.com/BrianLima/UWPHook/blob/master/UWPHook/Resources/GetAUMIDScript.ps1

However, instead of creating a wrapper like UWPHook, we find the exe and
add it directly to steam. This might not work for UWP games, but
probably most games are win32.

I included the `--skip-xbox-library` argument just in case this adds something someone doesn't want. All the other libraries can be skipped by setting their path to somewhere invalid, but xbox doesn't have paths, so this seemed appropriate.

Test
* Genesis Noir
* Monster Train
* Prey (2017)
* Rain on Your Parade
* Spiritfarer
* Supraland
* Tetris Effect
