### PR TITLE
Launch all xbox games with explorer

### DIFF
--- a/steamsync-library/src/itch.py
+++ b/steamsync-library/src/itch.py
@@ -2,9 +2,10 @@
 
 # LICENSE: AGPLv3. See LICENSE at root of repo
 
-from pathlib import Path
 import gzip
 import json
+from pathlib import Path
+
 import toml
 
 import defs
@@ -145,7 +146,8 @@ def itch_collect_games(path_to_library):
 
 
 def test():
-    import pprint, os
+    import os
+    import pprint
 
     games = itch_collect_games(os.path.expandvars("$APPDATA/itch/apps"))
     pprint.pprint(

--- a/steamsync-library/src/steameditor.py
+++ b/steamsync-library/src/steameditor.py
@@ -59,14 +59,16 @@ class SteamDatabase:
 
     """Database of steam information."""
 
-    def __init__(self, steam_path, cache_folder):
+    def __init__(self, steam_path, cache_folder, prefer_uri=False):
         """
         :steam_path: Path to folder containing steam.exe.
         :cache_folder: Where to store downloaded files.
+        :prefer_uri: Use uris for GameDefinitions where possible.
         """
         self._steam_path = Path(steam_path)
         self._cache_folder = Path(cache_folder)
         self._apps = self._load_app_list()
+        self._prefer_uri = prefer_uri
 
     def enumerate_steam_accounts(self):
         """
@@ -358,7 +360,7 @@ class SteamDatabase:
         _get_grid_art_destinations(GameDefinition, SteamAccount) -> dict[str,Path]
         """
         grid = Path(user.get_grid_folder(self._steam_path))
-        exe, args = game.get_launcher(use_uri=False)
+        exe, args = game.get_launcher(self._prefer_uri)
         shortcut = self._get_steam_shortcut_id(exe, game.display_name)
         # For some reason Big Picture uses 64 bit ids.
         # See https://github.com/scottrice/Ice/blob/7130b54c8d2fa7d0e2c0994ca1f2aa3fb2a27ba9/ice/steam_grid.py#L49-L64
@@ -375,7 +377,7 @@ def _test():
     import pprint
 
     db = SteamDatabase(
-        "C:/Program Files (x86)/Steam", os.path.expandvars("$TEMP/steamsync")
+        "C:/Program Files (x86)/Steam", os.path.expandvars("$TEMP/steamsync"), prefer_uri=False
     )
     user = db.enumerate_steam_accounts()[0]
     pprint.pp([user.steamid, user.username])

--- a/steamsync-library/src/steameditor.py
+++ b/steamsync-library/src/steameditor.py
@@ -358,7 +358,8 @@ class SteamDatabase:
         _get_grid_art_destinations(GameDefinition, SteamAccount) -> dict[str,Path]
         """
         grid = Path(user.get_grid_folder(self._steam_path))
-        shortcut = self._get_steam_shortcut_id(game.executable_path, game.display_name)
+        exe, args = game.get_launcher(use_uri=False)
+        shortcut = self._get_steam_shortcut_id(exe, game.display_name)
         # For some reason Big Picture uses 64 bit ids.
         # See https://github.com/scottrice/Ice/blob/7130b54c8d2fa7d0e2c0994ca1f2aa3fb2a27ba9/ice/steam_grid.py#L49-L64
         bp_shortcut = (shortcut << 32) | 0x02000000

--- a/steamsync-library/src/steameditor.py
+++ b/steamsync-library/src/steameditor.py
@@ -2,14 +2,14 @@
 
 # LICENSE: AGPLv3. See LICENSE at root of repo
 
-from datetime import datetime
-from pathlib import Path
 import binascii
 import json
 import os
-import unicodedata
 import re
 import shutil
+import unicodedata
+from datetime import datetime
+from pathlib import Path
 
 import requests
 import vdf

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -390,7 +390,10 @@ def add_games_to_shortcut_file(
             )
             print(v)
             continue
-        path_to_index[exe] = k
+        launch_args = v.get("LaunchOptions", "")
+        # Include args to handle mulitple explorer.exe options for xbox.
+        path = f"{exe}|{launch_args}"
+        path_to_index[path] = k
         appname = v.get("appname")
         if download_art_unsupported and exe not in supported_games:
             # Create a temp definition to specify info required to download.
@@ -423,8 +426,9 @@ def add_games_to_shortcut_file(
 
     game_results = []
     for game in games:
-        shortcut = game.uri if use_uri and game.uri else game.executable_path
-        i = path_to_index.get(shortcut, None)
+        shortcut = (game.uri) if use_uri and game.uri else game.executable_path
+        path = f"{shortcut}|{game.launch_arguments}"
+        i = path_to_index.get(path, None)
         if i:
             if replace_existing:
                 shortcuts["shortcuts"][i] = to_shortcut(game, use_uri)

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -219,7 +219,7 @@ def print_games(games):
                 i,
                 game.display_name[:25],
                 game.storetag,
-                game.app_name,
+                game.app_name[:45],
                 f"{game.executable_path} {game.launch_arguments}",
             )
         )

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -568,7 +568,9 @@ def main():
     steamid = args.steamid
     try:
         steamdb = steameditor.SteamDatabase(
-            args.steam_path, os.path.expandvars("$LOCALAPPDATA/steamsync/cache")
+            args.steam_path,
+            os.path.expandvars("$LOCALAPPDATA/steamsync/cache"),
+            args.use_uri,
         )
         accounts = steamdb.enumerate_steam_accounts()
     except FileNotFoundError as e:

--- a/steamsync-library/src/steamsync.py
+++ b/steamsync-library/src/steamsync.py
@@ -2,17 +2,17 @@
 
 import argparse
 import json
-import os
-from pathlib import Path
-import time
 import math
+import os
+import time
+from pathlib import Path
 
 import vdf
 
-from itch import itch_collect_games
-from xbox import xbox_collect_games
 import defs
 import steameditor
+from itch import itch_collect_games
+from xbox import xbox_collect_games
 
 
 def parse_arguments():

--- a/steamsync-library/src/xbox.py
+++ b/steamsync-library/src/xbox.py
@@ -114,11 +114,11 @@ def xbox_collect_games():
             if not is_game and not _is_game_judging_by_manifest(config):
                 continue
 
-            # exes without a MicrosoftGame.config cannot be run directly. We
-            # need to use explorer to launch them.
-            install = Path(os.path.expandvars("$WinDir"))
-            exe_name = "explorer.exe"
-            args = f"shell:appsFolder\\{app['Aumid']}"
+        # Xbox games put their version number in their path, so we can't rely
+        # on running the exe directly. We need to use explorer to launch by id.
+        install = Path(os.path.expandvars("$WinDir"))
+        exe_name = "explorer.exe"
+        args = f"shell:appsFolder\\{app['Aumid']}"
 
         if not exe_name:
             continue

--- a/steamsync-library/src/xbox.py
+++ b/steamsync-library/src/xbox.py
@@ -2,11 +2,11 @@
 
 # LICENSE: AGPLv3. See LICENSE at root of repo
 
-from pathlib import Path
-from xml.dom import minidom
 import json
 import os
 import subprocess
+from pathlib import Path
+from xml.dom import minidom
 
 import defs
 import util


### PR DESCRIPTION
**Bug**: sometimes new xbox games fail to launch.

**Reason**: Xbox games put their version number in their path, so we can't rely on
running the exe directly. We need to use explorer to launch by id or else the shortcut will break when the game updates.

* Switch to explorer.exe based launching.
* Add --remove-missing to clean up old xbox shortcuts and uninstalled games.
* Adjust game display formatting to show uris and limit appid length.
* Fix art download for uri games.

The game display now looks like this when using --use-uri:

```
Num | Game Name                 | Source     | App ID                                        | Executable
============================================================================================================
  1 | Axiom Verge               | epicstore  | Puffin                                        | com.epicgames.launcher://apps/Puffin?action=launch&silent=true
  2 | Carcassonne               | epicstore  | Thrush                                        | com.epicgames.launcher://apps/Thrush?action=launch&silent=true
  3 | Celeste                   | epicstore  | Salt                                          | com.epicgames.launcher://apps/Salt?action=launch&silent=true
  4 | Genesis Noir for Windows  | xbox       | SurpriseAttackPtyLtd.GenesisNoirforWindows_8k | C:/WINDOWS/explorer.exe shell:appsFolder\SurpriseAttackPtyLtd.GenesisNoirforWindows_8k24hnfn3vvj0!GenesisNoir
  5 | Ghost of a Tale PC        | xbox       | PlugInDigital.GhostofaTalePC_9e3ank8rmgj0t!Ga | C:/WINDOWS/explorer.exe shell:appsFolder\PlugInDigital.GhostofaTalePC_9e3ank8rmgj0t!Game
```

## Test

On master I started with:

steamsync.py --download-art --replace-existing  --all

	Carto                     | HumbleBundle.CartoWin10                            | C:\Program Files\WindowsApps\HumbleBundle.CartoWin10_1.0.73.0_x64__q2mcdwmzx4qja\Carto.exe
	Curse of the Dead Gods    | FocusHomeInteractiveSA.CurseoftheDeadGods-Windows1 | C:\Program Files\WindowsApps\FocusHomeInteractiveSA.CurseoftheDeadGods-Windows1_1.0.3.0_x64__4hny5m903y3g0\oTempleGame.exe
	Genesis Noir for Windows  | SurpriseAttackPtyLtd.GenesisNoirforWindows         | C:\Program Files\WindowsApps\SurpriseAttackPtyLtd.GenesisNoirforWindows_1.0.24.0_x64__8k24hnfn3vvj0\GenesisNoir.exe
	Ghost of a Tale PC        | PlugInDigital.GhostofaTalePC                       | C:\Program Files\WindowsApps\PlugInDigital.GhostofaTalePC_1.0.9.0_x64__9e3ank8rmgj0t\GhostofaTale.exe
	Katamari Damacy Reroll_Wi | NAMCOBANDAIGamesInc.KatamariDamacyRerollWindows    | C:\Program Files\WindowsApps\NAMCOBANDAIGamesInc.KatamariDamacyRerollWindows_1.0.19.0_x64__gdy2aq6ez762w\Katamari Damacy Reroll.exe
	Monster Train             | 69C22BB6.MonsterTrain                              | C:\Program Files\WindowsApps\69C22BB6.MonsterTrain_1.0.12838.0_x64__8ekbzbj4dakee\MonsterTrain.exe
	Prey                      | BethesdaSoftworks.LiluDallas-Multipass             | C:\Program Files\WindowsApps\BethesdaSoftworks.LiluDallas-Multipass_1.11.7.0_x64__3275kfvn8vcwc\Binaries\Danielle\Gaming.Desktop.x64\Release\Prey.exe
	Raji An Ancient Epic      | SUPER.COM.499901B22ECB3                            | C:\Program Files\WindowsApps\SUPER.COM.499901B22ECB3_1.0.3.0_x64__khac1bdnsjzc4\Raji\Binaries\WinGDK\Raji-WinGDK-Shipping.exe
	ReCore                    | Microsoft.ReCore                                   | C:\WINDOWS\explorer.exe shell:appsFolder\Microsoft.ReCore_8wekyb3d8bbwe!App
	Recompile                 | PlugInDigital.Recompile                            | C:\Program Files\WindowsApps\PlugInDigital.Recompile_1.0.3.0_x64__9e3ank8rmgj0t\Recompile.exe
	Supraland                 | HumbleBundle.SupralandWin10                        | C:\Program Files\WindowsApps\HumbleBundle.SupralandWin10_1.21.18.0_x64__q2mcdwmzx4qja\Supraland\Binaries\WinGDK\Supraland-WinGDK-Shipping.exe
	Tetris® Effect: Connected | 48710EnhanceIncorporated.TRIP2.0                   | C:\Program Files\WindowsApps\48710EnhanceIncorporated.TRIP2.0_1.2.2.0_x64__63vy8jfbpt4dt\TetrisEffect\Binaries\WinGDK\TetrisEffect-WinGDK-Shipping.exe

After using this branch to update:
`steamsync.py --download-art --replace-existing --remove-missing --all`

The game selection table shows the exe and not the thing we're planning to use.

	Carto                     | HumbleBundle.CartoWin10_q2mcdwmzx4qja!Game                                      | C:\Program Files\WindowsApps\HumbleBundle.CartoWin10_1.0.73.0_x64__q2mcdwmzx4qja\Carto.exe
	Curse of the Dead Gods    | FocusHomeInteractiveSA.CurseoftheDeadGods-Windows1_4hny5m903y3g0!Game           | C:\Program Files\WindowsApps\FocusHomeInteractiveSA.CurseoftheDeadGods-Windows1_1.0.3.0_x64__4hny5m903y3g0\oTempleGame.exe
	Genesis Noir for Windows  | SurpriseAttackPtyLtd.GenesisNoirforWindows_8k24hnfn3vvj0!GenesisNoir            | C:\Program Files\WindowsApps\SurpriseAttackPtyLtd.GenesisNoirforWindows_1.0.24.0_x64__8k24hnfn3vvj0\GenesisNoir.exe
	Ghost of a Tale PC        | PlugInDigital.GhostofaTalePC_9e3ank8rmgj0t!Game                                 | C:\Program Files\WindowsApps\PlugInDigital.GhostofaTalePC_1.0.9.0_x64__9e3ank8rmgj0t\GhostofaTale.exe
	Katamari Damacy Reroll_Wi | NAMCOBANDAIGamesInc.KatamariDamacyRerollWindows_gdy2aq6ez762w!Game              | C:\Program Files\WindowsApps\NAMCOBANDAIGamesInc.KatamariDamacyRerollWindows_1.0.19.0_x64__gdy2aq6ez762w\Katamari Damacy Reroll.exe
	Monster Train             | 69C22BB6.MonsterTrain_8ekbzbj4dakee!Game                                        | C:\Program Files\WindowsApps\69C22BB6.MonsterTrain_1.0.12838.0_x64__8ekbzbj4dakee\MonsterTrain.exe
	Prey                      | BethesdaSoftworks.LiluDallas-Multipass_3275kfvn8vcwc!App                        | C:\Program Files\WindowsApps\BethesdaSoftworks.LiluDallas-Multipass_1.11.7.0_x64__3275kfvn8vcwc\Binaries\Danielle\Gaming.Desktop.x64\Release\Prey.exe
	Raji An Ancient Epic      | SUPER.COM.499901B22ECB3_khac1bdnsjzc4!AppRajiShipping                           | C:\Program Files\WindowsApps\SUPER.COM.499901B22ECB3_1.0.3.0_x64__khac1bdnsjzc4\Raji\Binaries\WinGDK\Raji-WinGDK-Shipping.exe
	Recompile                 | PlugInDigital.Recompile_9e3ank8rmgj0t!Game                                      | C:\Program Files\WindowsApps\PlugInDigital.Recompile_1.0.3.0_x64__9e3ank8rmgj0t\Recompile.exe
	Supraland                 | HumbleBundle.SupralandWin10_q2mcdwmzx4qja!AppSupralandShipping                  | C:\Program Files\WindowsApps\HumbleBundle.SupralandWin10_1.21.18.0_x64__q2mcdwmzx4qja\Supraland\Binaries\WinGDK\Supraland-WinGDK-Shipping.exe
	Tetris® Effect: Connected | 48710EnhanceIncorporated.TRIP2.0_63vy8jfbpt4dt!AppTetrisEffectConnectedShipping | C:\Program Files\WindowsApps\48710EnhanceIncorporated.TRIP2.0_1.2.2.0_x64__63vy8jfbpt4dt\TetrisEffect\Binaries\WinGDK\TetrisEffect-WinGDK-Shipping.exe


	Replacing Carto (C:\Program Files\WindowsApps\HumbleBundle.CartoWin10_1.0.73.0_x64__q2mcdwmzx4qja\Carto.exe )
		with Carto (C:/WINDOWS/explorer.exe shell:appsFolder\HumbleBundle.CartoWin10_q2mcdwmzx4qja!Game)
	Replacing Curse of the Dead Gods (C:\Program Files\WindowsApps\FocusHomeInteractiveSA.CurseoftheDeadGods-Windows1_1.0.3.0_x64__4hny5m903y3g0\oTempleGame.exe )
		with Curse of the Dead Gods (C:/WINDOWS/explorer.exe shell:appsFolder\FocusHomeInteractiveSA.CurseoftheDeadGods-Windows1_4hny5m903y3g0!Game)
	Replacing Genesis Noir for Windows (C:\Program Files\WindowsApps\SurpriseAttackPtyLtd.GenesisNoirforWindows_1.0.24.0_x64__8k24hnfn3vvj0\GenesisNoir.exe )
		with Genesis Noir for Windows (C:/WINDOWS/explorer.exe shell:appsFolder\SurpriseAttackPtyLtd.GenesisNoirforWindows_8k24hnfn3vvj0!GenesisNoir)
	Replacing Ghost of a Tale PC (C:\Program Files\WindowsApps\PlugInDigital.GhostofaTalePC_1.0.9.0_x64__9e3ank8rmgj0t\GhostofaTale.exe )
		with Ghost of a Tale PC (C:/WINDOWS/explorer.exe shell:appsFolder\PlugInDigital.GhostofaTalePC_9e3ank8rmgj0t!Game)
	Replacing Katamari Damacy Reroll_Windows (C:\Program Files\WindowsApps\NAMCOBANDAIGamesInc.KatamariDamacyRerollWindows_1.0.19.0_x64__gdy2aq6ez762w\Katamari Damacy Reroll.exe )
		with Katamari Damacy Reroll_Windows (C:/WINDOWS/explorer.exe shell:appsFolder\NAMCOBANDAIGamesInc.KatamariDamacyRerollWindows_gdy2aq6ez762w!Game)
	Replacing Monster Train (C:\Program Files\WindowsApps\69C22BB6.MonsterTrain_1.0.12838.0_x64__8ekbzbj4dakee\MonsterTrain.exe )
		with Monster Train (C:/WINDOWS/explorer.exe shell:appsFolder\69C22BB6.MonsterTrain_8ekbzbj4dakee!Game)
	Replacing Prey (C:\Program Files\WindowsApps\BethesdaSoftworks.LiluDallas-Multipass_1.11.7.0_x64__3275kfvn8vcwc\Binaries\Danielle\Gaming.Desktop.x64\Release\Prey.exe )
		with Prey (C:/WINDOWS/explorer.exe shell:appsFolder\BethesdaSoftworks.LiluDallas-Multipass_3275kfvn8vcwc!App)
	Replacing Raji An Ancient Epic (C:\Program Files\WindowsApps\SUPER.COM.499901B22ECB3_1.0.3.0_x64__khac1bdnsjzc4\Raji\Binaries\WinGDK\Raji-WinGDK-Shipping.exe )
		with Raji An Ancient Epic (C:/WINDOWS/explorer.exe shell:appsFolder\SUPER.COM.499901B22ECB3_khac1bdnsjzc4!AppRajiShipping)
	Replacing Recompile (C:\Program Files\WindowsApps\PlugInDigital.Recompile_1.0.3.0_x64__9e3ank8rmgj0t\Recompile.exe )
		with Recompile (C:/WINDOWS/explorer.exe shell:appsFolder\PlugInDigital.Recompile_9e3ank8rmgj0t!Game)
	Replacing Supraland (C:\Program Files\WindowsApps\HumbleBundle.SupralandWin10_1.21.18.0_x64__q2mcdwmzx4qja\Supraland\Binaries\WinGDK\Supraland-WinGDK-Shipping.exe )
		with Supraland (C:/WINDOWS/explorer.exe shell:appsFolder\HumbleBundle.SupralandWin10_q2mcdwmzx4qja!AppSupralandShipping)
	Replacing Tetris® Effect: Connected (C:\Program Files\WindowsApps\48710EnhanceIncorporated.TRIP2.0_1.2.2.0_x64__63vy8jfbpt4dt\TetrisEffect\Binaries\WinGDK\TetrisEffect-WinGDK-Shipping.exe )
		with Tetris® Effect: Connected (C:/WINDOWS/explorer.exe shell:appsFolder\48710EnhanceIncorporated.TRIP2.0_63vy8jfbpt4dt!AppTetrisEffectConnectedShipping)

All of those games launch correctly from Steam for me.


~However, I'm not seeing any art download and I'm not sure why yet (hence draft pr). I haven't had much time to work on this, but I thought I should post soon so you can see the bug I introduced :(~