### PR TITLE
Prevent crash when itch game doesn't have cover art

### DIFF
--- a/steamsync-library/src/itch.py
+++ b/steamsync-library/src/itch.py
@@ -126,7 +126,7 @@ def itch_collect_games(path_to_library):
             f"{game_root_dir.name}{label}",
             working_dir,
             args,
-            g["coverUrl"],
+            g.get("coverUrl"),
             defs.TAG_ITCH,
         )
         games.append(game_def)


### PR DESCRIPTION
Fix KeyError: 'coverUrl' when an itch game doesn't have cover art.

We'll probably fail to find any art for it, but that's okay.