### PR TITLE
Read and write shortcut ids to vdf to fix downloaded art

### DIFF
--- a/steamsync/steamsync/steameditor.py
+++ b/steamsync/steamsync/steameditor.py
@@ -58,6 +58,11 @@ class SteamAccount:
     def get_user_folder(self, steam_folder):
         return f"{steam_folder}/userdata/{self.steamid}"
 
+    def get_shortcut_filepath(self, steam_folder):
+        return os.path.join(
+            steam_folder, "userdata", self.steamid, "config/shortcuts.vdf"
+        )
+
 
 class SteamDatabase:
 

--- a/steamsync/steamsync/steameditor.py
+++ b/steamsync/steamsync/steameditor.py
@@ -210,6 +210,10 @@ class SteamDatabase:
                 if appid:
                     break
         if not appid:
+            # For: "Death's Door Win10" -> "Death's Door"
+            stripped = re.sub(r" win10\b", "", name, 1)
+            appid = name_to_id.get(stripped)
+        if not appid:
             # For: "Yakuza Kiwami (PC)" -> "Yakuza Kiwami"
             stripped = re_remove_braces.sub("", name, 1)
             appid = name_to_id.get(stripped)
@@ -403,7 +407,7 @@ def _test():
     )
     user = db.enumerate_steam_accounts()[0]
     pprint.pp([user.steamid, user.username])
-    game_name = "Raji An Ancient Epic"
+    game_name = "Death's Door Win10"
     appid = db.guess_appid(game_name)
     print(game_name, appid)
 

--- a/steamsync/steamsync/steamsync.py
+++ b/steamsync/steamsync/steamsync.py
@@ -1,23 +1,21 @@
 # LICENSE: AGPLv3. See LICENSE at root of repo
 
 import argparse
-import json
 import os
-import sys
-import time
 import platform
+import time
 from pathlib import Path
 
 import appdirs
 import vdf
 
 import steamsync.defs as defs
-from steamsync.launchers.egs import EpicGamesStoreLauncher
-from steamsync.launchers.launcher import Launcher
 import steamsync.steameditor as steameditor
+from steamsync.launchers.egs import EpicGamesStoreLauncher
 from steamsync.launchers.itch import ItchLauncher
-from steamsync.launchers.xbox import XboxLauncher
+from steamsync.launchers.launcher import Launcher
 from steamsync.launchers.legendary import LegendaryLauncher
+from steamsync.launchers.xbox import XboxLauncher
 
 
 def get_default_steam_path():


### PR DESCRIPTION
Read and write shortcut ids to vdf

Fix #37: Downloaded art no longer displays in Steam.

Valve changed how Steam identifies art. Instead of hashing the exe and
name, it generates a shortcut id and stores it in shortcuts.vdf as
'appid'. Presumably this is so art is preserved when renaming shortcuts.

We can't wait for steam to populate the shortcut_id for our newly added
shortcuts, so instead we use the old method to generate a shortcut_id
and write it into the vdf. After removing other shortcuts and multiple
restarts of Steam, it seems that this method reliably and permanently
sets a shortcut id.

Also use the new name format for big picture art. It now matches the id
format of the others.

Test
* Use steamsync to add 4 shortcuts from Xbox with art and they all show
  up. Remove one from within Steam and restart. The other three still
  have their art.
* Use steamsync to add a bunch of epic and itchio shortcuts and their
  art looks correct art except itchio ones using gifs (which aren't
  supported by steam).


Also adds a `--dump-shortcut-vdf` argument which is helpful to debug this kind of issue.

Also handles "Win10" suffix on games when detecting appid. I was testing with Death's Door and it wasn't detected correctly.
