### PR TITLE
Fix xbox games no longer import (due to copilot manifest utf error)

### DIFF
--- a/steamsync/steamsync/launchers/xbox.py
+++ b/steamsync/steamsync/launchers/xbox.py
@@ -5,6 +5,7 @@
 import json
 import os
 import subprocess
+import xml.parsers.expat
 from pathlib import Path
 from xml.dom import minidom
 
@@ -152,8 +153,13 @@ def _is_game_judging_by_manifest(path_to_manifest):
 
     _is_game_judging_by_manifest(Path) -> bool
     """
-    with path_to_manifest.open("r", encoding="utf-8") as f:
-        doc = minidom.parse(f)
+    with path_to_manifest.open("r", encoding="utf-8", errors="ignore") as f:
+        try:
+            doc = minidom.parse(f)
+        except xml.parsers.expat.ExpatError as e:
+            # If unparsable, then it failed to tell us it's a game.
+            print(f"Failed to parse manifest and assuming not a game: '{path_to_manifest.as_posix()}'")
+            return None
 
     # Exclude Xbox apps which may otherwise look like a game
     name = [


### PR DESCRIPTION
Fix failure to process xbox games because minidom can't parse Copilot's manifest:

    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte

Adding a print(f) before the minidom.parse shows that the failure was from Copilot:

    <_io.TextIOWrapper name='C:\\Program Files\\WindowsApps\\Microsoft.Copilot_1.1.9.0_neutral__8wekyb3d8bbwe\\AppxManifest.xml' mode='r' encoding='utf-8'>

I think this issue has made xbox importing fail since Microsoft added the Copilot app. I didn't notice for a long time because it's just logged as "Unexpected failure collecting games from xbox." 



Ignore errors when loading the manifest so it's more likely we can read it. If it ends up being unparsable, then the manifest failed to tell us it's a game and that's fine.

Alternatively, we could catch this specific error but I don't think the failure really matters.

Test
* xbox import now completes successfully.
* Changed parse line to force parse failure:
```python
    doc = minidom.parseString("malformedxml"+f.read())
```
  See output and games continue to import correctly:
> Failed to parse manifest and assuming not a game: 'C:/Program Files/WindowsApps/Microsoft.Xbox.TCUI_1.24.10001.0_x64__8wekyb3d8bbwe/AppxManifest.xml'