### PR TITLE
Don't fail to add itch games with .console.exe

### DIFF
--- a/steamsync/steamsync/launchers/itch.py
+++ b/steamsync/steamsync/launchers/itch.py
@@ -6,11 +6,10 @@ import gzip
 import json
 from pathlib import Path
 
-import toml
-
 import steamsync.defs as defs
-import steamsync.util as util
 import steamsync.launchers.launcher as launcher
+import steamsync.util as util
+import toml
 
 
 class ItchLauncher(launcher.Launcher):

--- a/steamsync/steamsync/launchers/itch.py
+++ b/steamsync/steamsync/launchers/itch.py
@@ -52,6 +52,9 @@ class ItchLauncher(launcher.Launcher):
                     print(f"Warning: Failed to find executable for game '{title}'.")
                     continue
                 if len(exes) > 1:
+                    # Ignore Godot's extra game.console.exe executable.
+                    exes = [exe for exe in exes if exe.name.endswith(".console.exe")]
+                if len(exes) > 1:
                     exes_list = "\n".join(str(e) for e in exes)
                     print(
                         f"Warning: Skipping game '{title}' with multiple executables:\n{exes_list}"


### PR DESCRIPTION
Godot 4 exports games with two executables:
1. blah.exe - the normal game
2. blah.console.exe - runs the game *and* opens a console window for
   output

If there are both, then ignore the .console.exe one instead of failing
to import the game.

We could filter it out sooner, but it's possible that it's the only exe
in the package.