### PR TITLE
Allow 'quit' in game selection prompt

### DIFF
--- a/steamsync/steamsync/steamsync.py
+++ b/steamsync/steamsync/steamsync.py
@@ -177,11 +177,13 @@ def print_games(games, use_uri):
 
 def filter_games(games):
     print(
-        "Which games do you want to install (blank = all, or comma separated list of numbers from table)?"
+        "Which games do you want to install (blank = all, comma separated list of numbers from table, q to quit)?"
     )
     selection = input(": ").strip()
     if selection == "":
         return games
+    if selection[0] == "q":
+        return False
 
     selection = selection.split(",")
 
@@ -625,6 +627,10 @@ def main():
         picks = None
         while not picks:
             picks = filter_games(games)
+            if picks is False:
+                print("Quitting...")
+                return 1
+
         games = picks
 
     # 4. Pick the account to add shortcuts to (if needed)


### PR DESCRIPTION
I often change my mind at this point and the only way to get out is to Ctrl-c. Add a quit command so you can type 'q' or 'quit' to cancel selection and abort.

Alternatives: Could return "quit" or [] or adding a second return value, but returning False seems cleaner.