### PR TITLE
FIX: Update Steam App List API endpoint and JSON structure

### DIFF
--- a/steamsync/steamsync/steameditor.py
+++ b/steamsync/steamsync/steameditor.py
@@ -155,9 +155,9 @@ class SteamDatabase:
         if not data:
             print("Downloading latest app list from Steam...")
             response = requests.get(
-                "http://api.steampowered.com/ISteamApps/GetAppList/v2"
+                "https://api.steampowered.com/IStoreService/GetAppList/v1/?key=API_KEY_PLACEHOLDER&max_results=50000"
             )
-            apps = response.json()["applist"]["apps"]
+            apps = response.json()["response"]["apps"]
             name_to_id = {}
             stripped_to_id = {}
             for g in apps:


### PR DESCRIPTION
This pull request resolves the API fetching error reported in issue #48, which caused a `JSONDecodeError` and subsequent `KeyError: 'applist'`.

The Steam Web API endpoint used to fetch the full list of apps (`ISteamApps/GetAppList/v2/`) appears to be retired or unreliable.

### Changes Included:

1.  **Updated API Endpoint:** The app list fetching URL in `steamsync/steameditor.py` has been updated to the working endpoint: `IStoreService/GetAppList/v1/`.
2.  **JSON Structure Update:** The key lookup has been changed from `response.json()["applist"]["apps"]` to `response.json()["response"]["apps"]` to match the new endpoint's structure.

### NOTE for the Maintainer: API Key Requirement

The new endpoint requires a [Steam Web API Key](https://steamcommunity.com/dev/apikey) (`?key=...`) to function. I have used the placeholder `API_KEY_PLACEHOLDER` in the code to prevent committing my private key.

The application logic will need to be updated to securely:
a) Obtain the user's Steam Web API Key (e.g., from an environment variable or config file).
b) Substitute this key into the URL string before making the API call.

Closes #48